### PR TITLE
Heading Error

### DIFF
--- a/Scripts/FeatureLineWhiskers.py
+++ b/Scripts/FeatureLineWhiskers.py
@@ -52,7 +52,7 @@ def get_line_heading(polyline_obj, in_azimuth=False):
     last_y = last_point.Y
     dx = last_x - first_x
     dy = last_y - first_y
-    rads = math.atan2(dy, dx)
+    rads = math.atan2(dx, dy)
     angle = math.degrees(rads)
     if in_azimuth:
         angle = get_azimuth(angle)

--- a/Scripts/linelibrary.py
+++ b/Scripts/linelibrary.py
@@ -335,7 +335,7 @@ def calculate_line_bearing(in_fc, field, convert_azimuth=False):
             last_y = last_point.Y
             dx = last_x - first_x
             dy = last_y - first_y
-            rads = math.atan2(dy, dx)
+            rads = math.atan2(dx, dy)
             angle = math.degrees(rads)
             if convert_azimuth:
                 angle = convert_to_azimuth(angle)

--- a/Scripts/linelibrary.py
+++ b/Scripts/linelibrary.py
@@ -335,7 +335,7 @@ def calculate_line_bearing(in_fc, field, convert_azimuth=False):
             last_y = last_point.Y
             dx = last_x - first_x
             dy = last_y - first_y
-            rads = math.atan2(dx, dy)
+            rads = math.atan2(dy, dx)
             angle = math.degrees(rads)
             if convert_azimuth:
                 angle = convert_to_azimuth(angle)


### PR DESCRIPTION
The arctan2 function should have a negative y or dx first to be relative to north. All the tools work because they operate on relative angles. The headings are off, but the tool functionality stayed the same. 